### PR TITLE
Allow to put the app in favorites

### DIFF
--- a/package-append.json
+++ b/package-append.json
@@ -50,7 +50,8 @@
         "GenericName": "Online music streaming service",
         "Comment": "Listen and download all your favorite music",
         "MimeType": "x-scheme-handler/deezer;",
-        "Keywords": "Music;Player;Streaming;Online;"
+        "Keywords": "Music;Player;Streaming;Online;",
+        "StartupWMClass": "Deezer"
       },
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },


### PR DESCRIPTION
Hello! 🙂

It's a little fix to allow to put the app in favorites. The default `StartupWMClass` in the desktop file is `deezer-desktop` where it should be just `deezer` or `Deezer`. 
I tried it with a full deb build and it works. Maybe, it should be tested for other builds.

Fixes: #8 