### PR TITLE
Fix mime type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ prepare: clean install_build_deps
 	@echo "Hide to tray when closing (https://github.com/SibrenVasse/deezer/issues/4)"
 	@echo "Start in tray cli option (https://github.com/SibrenVasse/deezer/pull/12)"
 	@echo "Remove kernel version from User-Agent (https://github.com/aunetx/deezer-linux/pull/9)"
+	@echo "Avoid to set the text/html mime type (https://github.com/aunetx/deezer-linux/issues/13)"
 	$(foreach p, $(wildcard ./patches/*), patch -p1 -dapp < $(p);)
 
 	@echo "Append `package-append.json` to the `package.json` of the app"

--- a/patches/avoid-change-default-texthtml-mime-type.patch
+++ b/patches/avoid-change-default-texthtml-mime-type.patch
@@ -1,0 +1,18 @@
+diff --git a/build/main.js b/build/main.js
+index de51acb..e2c0b9e 100644
+--- a/build/main.js
++++ b/build/main.js
+@@ -2897,12 +2897,7 @@
+                 this.tray.init(),
+                 this.updater.init(),
+                 this.network.watch(),
+-                this.powerSave.check(),
+-                this.deepLink.getSchemes().forEach((scheme) => {
+-                  external_electron_namespaceObject.app.setAsDefaultProtocolClient(
+-                    scheme
+-                  );
+-                });
++                this.powerSave.check();
+               const dzrFilter = { urls: ["*://*/*"] },
+                 DOMAINS_WHITELIST = [
+                   "deezer.com",


### PR DESCRIPTION
Hello ! 🙂

This patch fixes #13 
After several searches, the xdg-settings bug is still not resolved: https://gitlab.freedesktop.org/xdg/xdg-utils/-/issues/180
And finally, I don't know if update electron version could solve anything.
As explain here https://github.com/lbryio/lbry-desktop/pull/5617 the bug appears when we call `setAsDefaultProtocolClient` on Linux. There is the concerned lines on xdg-utils issue.
Signal has change the production name and remove the dash from the desktop file `signal-desktop.desktop` to `signal.desktop` but for some app, like deezer-linux, it seems to not work.
So, I've chosen the LBRY way that avoid the call to this function if the platform is `linux`. As deezer-linux is only for linux, I don't put the condition, but we can.

I tested with the deb build and all works (start app, login via browser, listen music, etc).