### PR TITLE
Fix #21 app must stay in background by default

### DIFF
--- a/patches/quit.patch
+++ b/patches/quit.patch
@@ -2,7 +2,7 @@ diff --git a/build/main.js b/build/main.js
 index 5066eef..46b04c5 100644
 --- a/build/main.js
 +++ b/build/main.js
-@@ -3079,7 +3080,7 @@
+@@ -3083,7 +3083,10 @@
              this._adjustViewToContentSize(),
              mainView.setAutoResize({ width: !0, height: !0 });
          } else this.appService.setWindow(this.window, void 0);


### PR DESCRIPTION
Hello ! 🙂

This PR is to fix #21 
After closing the app, it is not stayed in background and, obviously, the systray disappeared. I noticed that the `quit.patch` was not applied like the other patches. With this change, it is finally applied. I think this is caused by the `fix-isDev-usage.patch`. It is applied in first, shifts the lines and the patch provided by `quit.patch` is not found.

So, with this PR, it works fine. But, it's possible that the bug will come back after merging the PR #20 for example...
Is there another way to apply patches?