### PR TITLE
docs: add requirements to build from sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ Please note that eventhough it is automatically generated, the snapcraft package
 
 ## From source
 
-You will probably need to install some things in order to generate the packages from source: `nodejs` and `npm`, and `yarn` at least; and `flatpak-builder` to build the flatpak version.
+You will probably need to install some things in order to generate the packages from source:
+
+- nodejs
+- npm
+- yarn
+- 7z by installing `p7zip` and `p7zip-full`
+- make
+- wget
+- `flatpak-builder` (only to build the flatpak version)
 
 ### Flatpak
 


### PR DESCRIPTION
Hello! :slightly_smiling_face:

This PR adds requirements to build from sources, in the README.
I started in a docker image of Ubuntu, from scratch, tried to run `make install_deps` and reported in these changes the packages that I had to install to avoid errors and succeed the installation.
Hope nothing is missing.

By the way, it's to close #27 

:wave: