### PR TITLE
Add automatic update checker

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -13,7 +13,7 @@ jobs:
         branch: [ master ] # list all branches to check
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -1,0 +1,29 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 0 * * 1" # run every Monday
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab 
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ master ] # list all branches to check
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork dev.aunetx.deezer.json

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ prepare: clean install_build_deps
 
 	@echo "Download installer"
 	@wget -nv -c $(BASE_URL) -O source/deezer-setup-$(PKGVER).exe
+	@echo "$(SHA256) deezer-setup-$(PKGVER).exe" | sha256sum -c --status || echo "SHA256 not matching!" && exit 1
 
 	@echo "Extract app archive from installer"
 	@cd source && 7z x -so deezer-setup-$(PKGVER).exe '$$PLUGINSDIR/app-32.7z' > app-32.7z

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Maintainer: Aurélien Hamy <aunetx@yandex.com>
 
 APPNAME = dev.aunetx.deezer
-PKGVER = 6.0.110
-BASE_URL = https://www.deezer.com/desktop/download/artifact/win32/x86/$(PKGVER)
+BASE_URL = $(shell jq ".modules[0].sources[0].url" dev.aunetx.deezer.json)
+SHA256 = $(shell jq ".modules[0].sources[0].sha256" dev.aunetx.deezer.json)
+PKGVER = $(shell echo $(BASE_URL) | grep -Eo "([0-9]+\.[0-9]+\.[0-9]+)" | head -1)
 VERSION_REGEX = ^v$(PKGVER)-[0-9]{1,}$$
 
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ prepare: clean install_build_deps
 	@mkdir -p source
 
 	@echo "Download installer"
-	@wget -nv -c $(BASE_URL) -O source/deezer-setup-$(PKGVER).exe
+	@wget -nv $(BASE_URL) -O source/deezer-setup-$(PKGVER).exe
 	@echo "$(SHA256) source/deezer-setup-$(PKGVER).exe" | sha256sum -c --status || echo "SHA256 not matching!" && exit 1
 
 	@echo "Extract app archive from installer"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ prepare: clean install_build_deps
 
 	@echo "Download installer"
 	@wget -nv -c $(BASE_URL) -O source/deezer-setup-$(PKGVER).exe
-	@echo "$(SHA256) deezer-setup-$(PKGVER).exe" | sha256sum -c --status || echo "SHA256 not matching!" && exit 1
+	@echo "$(SHA256) source/deezer-setup-$(PKGVER).exe" | sha256sum -c --status || echo "SHA256 not matching!" && exit 1
 
 	@echo "Extract app archive from installer"
 	@cd source && 7z x -so deezer-setup-$(PKGVER).exe '$$PLUGINSDIR/app-32.7z' > app-32.7z

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ prepare: clean install_build_deps
 
 	@echo "Download installer"
 	@wget -nv $(BASE_URL) -O source/deezer-setup-$(PKGVER).exe
-	@echo "$(SHA256) source/deezer-setup-$(PKGVER).exe" | sha256sum -c --status || echo "SHA256 not matching!" && exit 1
+
+	@echo "Verify installer"
+	@echo "$(SHA256) source/deezer-setup-$(PKGVER).exe" | sha256sum -c --status || exit 1
 
 	@echo "Extract app archive from installer"
 	@cd source && 7z x -so deezer-setup-$(PKGVER).exe '$$PLUGINSDIR/app-32.7z' > app-32.7z

--- a/dev.aunetx.deezer.json
+++ b/dev.aunetx.deezer.json
@@ -1,0 +1,22 @@
+{
+  "app-id": "dev.aunetx.deezer",
+  "modules": [
+    {
+      "name": "deezer",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/win32/x86/6.0.150/DeezerDesktopSetup_6.0.150.exe",
+          "sha256": "0ecf85dc7988bc1c26bf12f22b800eeb813b943b7453b8ac5fa9a103ccc075f5",
+          "only-arches": ["x86_64"],
+          "dest": "archive",
+          "x-checker-data": {
+            "type": "rotating-url",
+            "url": "https://www.deezer.com/desktop/download?platform=win32&architecture=x86",
+            "pattern": "([\\d]+\\.[\\d]+\\.[\\d]+)"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change automatizes syncing new Deezer releases, keeping the Linux version closer to the latest official release. I've also updated the current version to the latest one as of now, which is 6.0.150.

A GitHub Secret is needed for the FlatHub Bot so that it can automatically commit the new update and open a PR.