### PR TITLE
Update Github Actions to latest version

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
   
     - name: install_deps
       run: make install_deps
@@ -44,7 +44,7 @@ jobs:
       run: echo "$(sha256sum artifacts/{x64,arm64}/*.{deb,rpm,AppImage,tar.xz})" > sha256
 
     - name: create release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ env.version }}
         body: 'Update to version ${{ env.version }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
 
     - name: install_deps
       run: make install_deps
@@ -21,11 +21,11 @@ jobs:
     - name: build_appimage_arm64
       run: make build_appimage_arm64
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: deezer-desktop-nightly-build-x64.AppImage
         path: artifacts/x64/deezer-desktop-*.AppImage
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: deezer-desktop-nightly-build-arm64.AppImage
         path: artifacts/arm64/deezer-desktop-*.AppImage


### PR DESCRIPTION
This also updates Node to v20.

> With the introduction of v4, we will be deprecating v1 and v2 of actions/upload-artifact, actions/download-artifact, and related npm packages on June 30, 2024

Source 1: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
Source 2: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/