### PR TITLE
Disable AppImage update check of Official Deezer channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ prepare: clean install_build_deps
 	@echo "Remove kernel version from User-Agent (https://github.com/aunetx/deezer-linux/pull/9)"
 	@echo "Avoid to set the text/html mime type (https://github.com/aunetx/deezer-linux/issues/13)"
 	@echo "Add a better management of MPRIS (https://github.com/aunetx/deezer-linux/pull/61)"
+	@echo "Disable AppImage update check of Official Deezer channel (https://github.com/aunetx/deezer-linux/pull/65)"
 	$(foreach p, $(wildcard ./patches/*), patch -p1 -dapp < $(p);)
 
 	@echo "Append `package-append.json` to the `package.json` of the app"

--- a/patches/disable-update-check-official-channel.patch
+++ b/patches/disable-update-check-official-channel.patch
@@ -1,0 +1,13 @@
+diff --git a/build/main.js b/build/main.js
+index 764aa06..8a8a370 100644
+--- a/build/main.js
++++ b/build/main.js
+@@ -2362,7 +2362,7 @@
+       }
+       init() {
+         this.arch &&
+-          ((isPlatform(PLATFORM.LINUX) && !process.env.APPIMAGE) ||
++          (isPlatform(PLATFORM.LINUX) ||
+             isWindowsStore() ||
+             "yes" === process.env.DZ_DISABLE_UPDATE ||
+             ((external_electron_updater_namespaceObject.autoUpdater.autoDownload =


### PR DESCRIPTION
The Electron AppImage that we build attempts to check for updates using the Official Deezer Channel, which only supports Windows and possibly MacOS.

This patch disables the update check for Linux systems, however in the future we could revert this and implement our own update logic to support our own self-updating AppImages.

Example logs:

```
18:50:30.378 › Init App
Checking for update
Error: Error: This file could not be downloaded, or the latest version (from update server) does not have a valid semver version: "undefined"
    at Object.newError (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/node_modules/builder-util-runtime/src/index.ts:56:17)
    at AppImageUpdater.isUpdateAvailable (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/src/AppUpdater.ts:321:13)
    at AppImageUpdater.doCheckForUpdates (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/src/AppUpdater.ts:378:22)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
18:50:50.759 (main/warn) ›  Error: This file could not be downloaded, or the latest version (from update server) does not have a valid semver version: "undefined"
    at Object.newError (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/node_modules/builder-util-runtime/src/index.ts:56:17)
    at AppImageUpdater.isUpdateAvailable (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/src/AppUpdater.ts:321:13)
    at AppImageUpdater.doCheckForUpdates (/tmp/.mount_deezerGgAVl2/resources/app.asar/node_modules/electron-updater/src/AppUpdater.ts:378:22)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)

```