### PR TITLE
Feat: add Discord RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,8 @@ prepare: clean install_build_deps
 	$(foreach p, $(wildcard ./patches/*), patch -p1 -dapp < $(p);)
 
 	@echo "Append `package-append.json` to the `package.json` of the app"
-	@echo "Adds electron, elecron-builder dependencies, and build directives"
-	@head -n -1 app/package.json > tmp.txt && mv tmp.txt app/package.json
-	@cat package-append.json | tee -a app/package.json
+	@echo "Adds electron, elecron-builder dependencies, prod and build directives"
+	@jq -s '.[0] * .[1]' app/package.json package-append.json > app/tmp.json && mv app/tmp.json app/package.json
 
 	@echo "Download new packages"
 	@npm i

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It packages the app in a number of formats:
 - Snap (not tested yet)
 - AppImage (can't automatically login without desktop integration)
 - `rpm` (Fedora, Red Hat, CentOS, openSUSE, ...)
-- `deb` (Debian, Ubuntu, Pop!_OS, elementary OS, ...)
+- `deb` (Debian, Ubuntu, Pop!\_OS, elementary OS, ...)
 - `7z` to install anywhere else
 
 It was done thanks to the hard work of [SibrenVasse](https://github.com/SibrenVasse), who [packaged the app for the AUR](https://github.com/SibrenVasse/deezer).
@@ -53,7 +53,7 @@ To build the AppImage image from source, use:
 
 ```sh
 make install_deps
-make build_appimage
+make build_appimage_x64
 ```
 
 And the image should be in the `artifacts/x64` folder.
@@ -101,4 +101,4 @@ This work is UNOFFICIAL, and Deezer does not officially support Linux yet.
 
 Installing/using this is consequently probably outside of the scope of the Deezer EULA, and I am not responsible for your usage of this.
 
-I ***tried*** to talk to Deezer to ask them if I am authorized to upload this on Flathub, but when they answer, even if they say yes, this work is still unofficial.
+I **_tried_** to talk to Deezer to ask them if I am authorized to upload this on Flathub, but when they answer, even if they say yes, this work is still unofficial.

--- a/package-append.json
+++ b/package-append.json
@@ -16,7 +16,7 @@
     "build-appimage-arm64": "electron-builder --arm64 --linux AppImage"
   },
   "dependencies": {
-    "discord-rpc": "^4.0.0"
+    "rich-presence-builder": "^0.1.1"
   },
   "devDependencies": {
     "electron": "^13.6.9",

--- a/package-append.json
+++ b/package-append.json
@@ -1,4 +1,5 @@
- ,"scripts": {
+{
+  "scripts": {
     "copy-resources": "mkdir -p resources/linux && cp ../extra/linux/* ./resources/linux",
     "start": "yarn run copy-resources && electron .",
     "prepare-flatpak": "electron-builder --linux --dir",
@@ -13,6 +14,9 @@
     "build-deb-arm64": "electron-builder --arm64 --linux deb",
     "build-rpm-arm64": "electron-builder --arm64 --linux rpm",
     "build-appimage-arm64": "electron-builder --arm64 --linux AppImage"
+  },
+  "dependencies": {
+    "discord-rpc": "^4.0.0"
   },
   "devDependencies": {
     "electron": "^13.6.9",

--- a/patches/discord-rpc.patch
+++ b/patches/discord-rpc.patch
@@ -1,0 +1,38 @@
+diff --git a/app/build/main.js b/app/build/main.js
+index a02de6e..04ca93a 100644
+--- a/app/build/main.js
++++ b/app/build/main.js
+@@ -88,6 +88,15 @@
+       external_electron_devtools_installer_default = __webpack_require__.n(
+         external_electron_devtools_installer_namespaceObject
+       );
++    const external_rich_presence_builder_namespaceObject = require("rich-presence-builder");
++    var external_rich_presence_builder_default = __webpack_require__.n(
++      external_rich_presence_builder_namespaceObject
++    );
++
++    const rpc = new external_rich_presence_builder_namespaceObject({
++      clientID: "1244016234203185183"
++    });
++
+     function isPlatform(platform) {
+       switch (platform) {
+         case PLATFORM.WINDOWS:
+@@ -2225,10 +2234,16 @@
+           (this.media = media),
+           (this.menu = menu),
+           (this.user = user),
+-          this.media.addListener(MediaEvents.PlayerUpdated, () => {
++          this.media.addListener(MediaEvents.PlayerUpdated, (player) => {
++            rpc.setSmallImage(player.state === "playing" ? "play" : "pause", player.state === "playing" ? "Playing" : "Paused"),
++            rpc.go().catch();
+             this.setContextMenu();
+           }),
+           this.media.addListener(MediaEvents.TrackUpdated, (track) => {
++            rpc.setLargeImage(track.coverUrl);
++            rpc.setState(`${track.artist} - ${track.album}`);
++            rpc.setDescription(track.title);
++            rpc.go().catch();
+             this.setToolTip(`${track.title} - ${track.artist}`),
+               this.setContextMenu();
+           }),

--- a/patches/discord-rpc.patch
+++ b/patches/discord-rpc.patch
@@ -1,7 +1,9 @@
-diff --git a/app/build/main.js b/app/build/main.js
+Author: Josselin Dulongcourty "josselinonduty"
+---
+diff --git a/build/main.js b/build/main.js
 index a02de6e..04ca93a 100644
---- a/app/build/main.js
-+++ b/app/build/main.js
+--- a/build/main.js
++++ b/build/main.js
 @@ -88,6 +88,15 @@
        external_electron_devtools_installer_default = __webpack_require__.n(
          external_electron_devtools_installer_namespaceObject


### PR DESCRIPTION
The Discord Client ID can be changed by remove my client id in the patches/discord-rpc.patch file and adding yours. This could be stated in the README.

The discord project uses 2 assets: "play" and "pause".