### PR TITLE
Upgrade to 6.0.280. Fix rejected patch for MPRIS

### DIFF
--- a/dev.aunetx.deezer.json
+++ b/dev.aunetx.deezer.json
@@ -6,8 +6,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/win32/x86/6.0.150/DeezerDesktopSetup_6.0.150.exe",
-          "sha256": "0ecf85dc7988bc1c26bf12f22b800eeb813b943b7453b8ac5fa9a103ccc075f5",
+          "url": "https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/win32/x86/6.0.280/DeezerDesktopSetup_6.0.280.exe",
+          "sha256": "0363cd07af4af5b2f712f269238784385ca17e63628245ae470919f28d64e5ca",
           "only-arches": ["x86_64"],
           "dest": "archive",
           "x-checker-data": {

--- a/patches/better-management-of-MPRIS.patch
+++ b/patches/better-management-of-MPRIS.patch
@@ -133,6 +133,5 @@
      "lodash.get": "^4.4.2",
      "macos-version": "^5.2.1",
 +    "mpris-service": "^2.1.2",
-     "object.assign": "^4.1.2",
      "raven": "^2.6.4",
      "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
mpris.patch on `app/package.json` was rejected because `object.assign` is not anymore in dependencies 
