### PR TITLE
feat: adjust volume on wheel

### DIFF
--- a/patches/12-adjust-volume-on-wheel.patch
+++ b/patches/12-adjust-volume-on-wheel.patch
@@ -21,7 +21,7 @@ index d0f0f4d..559cd1a 100644
 +            const dzPlayer = window.dzPlayer;
 +            dzPlayer &&
 +              dzPlayer.control.setVolume(
-+                Math.max(0, Math.min(1, dzPlayer.volume + 0.1 * direction))
++                Math.max(0, Math.min(1, dzPlayer.volume + 0.05 * direction))
 +              );
 +          };
 +          document


### PR DESCRIPTION
I'm not sure if feature patches like this are welcome, but I figured if I found it useful, others might. If not, feel free to close/delete this.

This patch replicates how Spotify behaves. When you hover the volume button and scroll your mouse wheel, the volume changes up/down. It's pretty simple, and copies the logic of ctrl+up/down.

I had a bit of trouble figuring out how to know when the player loaded, but I found the `window.Events.player.playerReady` event useful. The renderer already subscribes to this, so I use that to add the mouse events. The actual slider is not a child of the button, so it requires 2 event subscribers. I use the aria-label to find the button - hopefully it's resistant to UI updates breaking the patch.