### PR TITLE
chore(cd): update checks and conditions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
 
 jobs:
   packages:
     name: "Build packages"
     runs-on: ubuntu-latest
+    if: github.event.base_ref == 'refs/heads/master'
     steps:
       - name: checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Checked on a forked that:

- [x] pushing a tag on non-master branch (i.e. any PR) does not trigger release workflow
- [x] pushing a tag on master branch does trigger release workflow
- [x] pushing a tag without `vM.m.p` or `vM.m.p-c` format does not trigger workflow