### PR TITLE
feat: Allow custom resources path via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Other packages can be installed from your package manager, either by clicking on
 | `DZ_DISABLE_ANIMATIONS`            | `yes`,`no`                                      | Disable animations (see [patch](./patches/09-disable-animations.patch))                        |
 | `DZ_DISABLE_NOTIFICATIONS`         | `yes`,`no`                                      | Disable notifications (see [patch](./patches/10-disable-notifications.patch))                  |
 | `DZ_DISABLE_HARDWARE_ACCELERATION` | `yes`,`no`                                      | Disable hardware acceleration (see [patch](./patches/13-disable-hardware-acceleration.patch))  |
+| `DZ_RESOURCES_PATH`                | _path_                                          | Override the default resources path (see [patch](./patches/14-override-resources-path.patch)) |
 | `DZ_DEVTOOLS`                      | `yes`,`no`                                      | Enable the developer console (ctrl+shift+i)                                                    |
 
 ## Building from source

--- a/patches/14-override-resources-path.patch
+++ b/patches/14-override-resources-path.patch
@@ -1,0 +1,29 @@
+From 411d15d899a87b8a09c4e4a9a0bfcbb0ec04d88b Mon Sep 17 00:00:00 2001
+From: FelixLusseau <94113911+FelixLusseau@users.noreply.github.com>
+Date: Sat, 21 Feb 2026 12:41:45 +0100
+Subject: [PATCH] feat: Allow custom resources path via environment variable
+
+This patch allows users to override the default resources path using
+the DZ_RESOURCES_PATH environment variable. This is useful for
+custom installations where resources like systray.png icon are not
+in the default location.
+---
+ build/main.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/main.js b/build/main.js
+index 6a6697d..0e03d05 100644
+--- a/build/main.js
++++ b/build/main.js
+@@ -134,7 +134,7 @@
+     return external_path_default().join(
+       isDev(app)
+         ? external_path_default().join(app.getAppPath(), "resources")
+-        : process.resourcesPath,
++        : process.env.DZ_RESOURCES_PATH || process.resourcesPath,
+       appIcon
+     );
+   }
+-- 
+2.52.0
+


### PR DESCRIPTION
Hi

As a long time user of the Deezer-Desktop app with the Ubuntu .deb and my own NixOS derivation, I tried to publish it on Nixpkgs https://github.com/NixOS/nixpkgs/pull/488329.  
A Nix derivation is a wrapper to build an app from source or prebuilded packages for Nix packages manager and NixOS users. For deezer-linux, it only consists to put the files in the right place from the `.tar.xz` releases.

One of the maintainers suggested https://github.com/NixOS/nixpkgs/pull/488329#pullrequestreview-3822284407 to use the Nixpkgs packaged Electron instead of the deezer-linux one to reduce the derivation complexity, keep Electron up-to-date and mainly to not rebuild and patch the included Electron to make it working on NixOS (because of the linker differences).

So I made it and I encountered an issue. The default `process.resourcesPath` is Electron one and not the folder packaged in the `.tar.xz` so the app is crashing at startup because it is not finding the `systray.png` icon.

```bash
❯ deezer-desktop
13:47:27.399 › Init App
(node:138859) UnhandledPromiseRejectionWarning: Error: Failed to load image from path '/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/resources/linux/systray.png'
    at TrayService.init (/nix/store/ffxw5dysivcsw0y18fysxl255rkjyjdq-deezer-desktop-7.1.70/share/deezer-desktop/resources/app.asar/build/main.js:2246:25)
    at Object.<anonymous> (/nix/store/ffxw5dysivcsw0y18fysxl255rkjyjdq-deezer-desktop-7.1.70/share/deezer-desktop/resources/app.asar/build/main.js:2934:25)
    at Generator.next (<anonymous>)
    at fulfilled (/nix/store/ffxw5dysivcsw0y18fysxl255rkjyjdq-deezer-desktop-7.1.70/share/deezer-desktop/resources/app.asar/build/main.js:2836:26)
(Use `electron --trace-warnings ...` to show where the warning was created)
(node:138859) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
^C
```

The only solution is to edit the `app.asar` because NixOS packages are readonly so it is not possible to edit Electron to symlink the file without rebuilding it (and go back to a similar of the initial derivation).

So I created a patch to the original app here to add the optional possibility to override the `process.resourcesPath` when loading the systray icon whithout breaking Deezer.

I tested it and it is solving the error.

If this patch is accepted and my Nixpkgs derivation PR too, the app will then be available on Nixpkgs for all NixOS users with your credits (because it is just a wrap) with the command `nix-shell -p deezer-desktop` or by adding it to their NixOS `configuration.nix` or Nix Flakes.

Thank you for your time and feel free to make suggestions on this PR if needed.