### PR TITLE
chore: remove star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ It packages the app in a number of formats:
 - `deb` (Debian, Ubuntu, Pop!\_OS, elementary OS, ...)
 - `tar.xz` to install anywhere else
 
+<!--
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=aunetx/deezer-linux&type=date&legend=top-left)](https://www.star-history.com/#aunetx/deezer-linux&type=date&legend=top-left)
-
-Special thanks to [SibrenVasse](https://github.com/SibrenVasse) who made the [original AUR package](https://github.com/SibrenVasse/deezer) for this app!
+-->
 
 ## Installation
 


### PR DESCRIPTION
Removed star history section since it requires an access token now