### PR TITLE
Feature : add Nix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,16 @@ build_flatpak_arm64:
 	@echo "Build Flatpak package"
 	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run build-flatpak-arm64
 
+build_nix_x64: 
+	@echo "Build Nix package"
+	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix
+	@nix-build -A deezer-desktop --argstr pkgVer "$(PKGVER)" --argstr arch "x64" --out-link ./artifacts/x64/nix-result
+
+build_nix_arm64: 
+	@echo "Build Nix package"
+	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix
+	@nix-build -A deezer-desktop --argstr pkgVer "$(PKGVER)" --argstr arch "arm64" --out-link ./artifacts/arm64/nix-result
+
 #! DEV
 
 patch-new: install_deps

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ build_flatpak_arm64:
 
 build_nix_x64: 
 	@echo "Build Nix package"
+	@uname -m | grep -Eq 'x86_64|amd64' || { echo "The x64 Nix target requires a native x86_64 host."; exit 1; }
 	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix -- --x64
 	@nix-build -A deezer-desktop --argstr pkgVer "$(PKGVER)" --argstr arch "x64" --out-link ./artifacts/x64/nix-result
 

--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,13 @@ build_flatpak_arm64:
 
 build_nix_x64: 
 	@echo "Build Nix package"
-	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix
+	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix -- --x64
 	@nix-build -A deezer-desktop --argstr pkgVer "$(PKGVER)" --argstr arch "x64" --out-link ./artifacts/x64/nix-result
 
 build_nix_arm64: 
 	@echo "Build Nix package"
-	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix
+	@uname -m | grep -Eq 'arm64|aarch64' || { echo "The arm64 Nix target requires a native arm64 host."; exit 1; }
+	@$(PACKAGE_MANAGER) $(PACKAGE_MANAGER_SUBDIR_ARG) $(APP_DIR) run prepare-nix -- --arm64
 	@nix-build -A deezer-desktop --argstr pkgVer "$(PKGVER)" --argstr arch "arm64" --out-link ./artifacts/arm64/nix-result
 
 #! DEV

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It packages the app in a number of formats:
 - `rpm` (Fedora, Red Hat, CentOS, openSUSE, ...)
 - `deb` (Debian, Ubuntu, Pop!\_OS, elementary OS, ...)
 - `tar.xz` to install anywhere else
+- Nix
 
 ## Star History
 
@@ -24,7 +25,26 @@ Special thanks to [SibrenVasse](https://github.com/SibrenVasse) who made the [or
 
 You can find all of the packages on [the release page](https://github.com/aunetx/deezer-linux/releases/latest).
 
+### Flatpak
+
 To install the flatpak version, you can simply go to https://flathub.org/apps/dev.aunetx.deezer (or use your favorite flatpak package manager).
+
+### Nix
+
+To install the [Nix version](https://search.nixos.org/packages?query=deezer-desktop&show=deezer-desktop) available in `unstable` and current releases, you can use:
+```sh
+nix-shell -p deezer-desktop
+```
+Or, to install it permanently, add it to your `configuration.nix` or Flakes:
+```nix
+{
+  environment.systemPackages = with pkgs; [
+    deezer-desktop
+  ];
+}
+```
+
+### Other packages
 
 Other packages can be installed from your package manager, either by clicking on them or from the command-line.
 
@@ -67,6 +87,7 @@ Other packages can be installed from your package manager, either by clicking on
 | tar.xz   | ⚠️    | ✅  |
 | snap     | ⚠️    | ✅  |
 | flatpak  | ⚠️    | ✅  |
+| nix      | ✅    | ✅  |
 
 ✅ Available ; ⚠️ Not tested ; ❌ Not available ; ⛔ Not planned
 
@@ -185,6 +206,21 @@ To run it, you can use:
 
 ```sh
 flatpak run dev.aunetx.deezer
+```
+
+### Nix
+
+To build the `nix` package, you can use:
+
+```sh
+nix-shell # Temporarily install dependencies from shell.nix in a shell
+make install_deps
+make build_nix_{arch}
+```
+
+To run it, you can use:
+```sh
+./artifacts/{arch}/nix-result/bin/deezer-desktop
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ After installing, launch **Deezer** from your applications menu, or from a termi
 | -------------------- | ------------------------------------------------------------------- |
 | Flatpak              | `flatpak run dev.aunetx.deezer`                                     |
 | Snap                 | `deezer-desktop`                                                    |
-| Nix                  | `deezer-desktop` or `nix-shell -p deezer-desktop`                   |
+| Nix                  | `deezer-desktop` or `nix run nixpkgs#deezer-desktop`                |
 | `.deb` / `.rpm`      | `deezer-desktop`                                                    |
 | `.tar.xz` / AppImage | `./deezer-desktop` (from the extracted folder or the AppImage file) |
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It packages the app in a number of formats:
 | **Flatpak**\* | Sandboxed, auto-updated, works everywhere         | [**Install from Flathub**](https://flathub.org/apps/dev.aunetx.deezer) or `flatpak install flathub dev.aunetx.deezer`                                                           |
 | **Snap**\*    | Ubuntu and Snap-based distros                     | [**Install from the Snap Store**](https://snapcraft.io/deezer-desktop) or `sudo snap install deezer-desktop`                                                                    |
 | **AppImage**  | A single portable file, no installation needed    | [Download from the releases page](https://github.com/aunetx/deezer-linux/releases/latest)                                                                                       |
-| **Nix**       | NixOS and other distros using Nix package manager | Add the [Nix version](https://search.nixos.org/packages?query=deezer-desktop&show=deezer-desktop) available in `unstable` and current releases to your configuration            |
+| **Nix**       | NixOS and other distros using Nix package manager | Add the [Nix version](https://search.nixos.org/packages?query=deezer-desktop&show=deezer-desktop) available in `unstable` and current releases to your configuration or run it once with `nix-shell -p deezer-desktop --run deezer-desktop`            |
 | **`.deb`**    | Debian, Ubuntu, Pop!\_OS, elementary OS…          | [Download from the releases page](https://github.com/aunetx/deezer-linux/releases/latest)                                                                                       |
 | **`.rpm`**    | Fedora, Red Hat, CentOS, openSUSE…                | [Download from the releases page](https://github.com/aunetx/deezer-linux/releases/latest)                                                                                       |
 | **`.tar.xz`** | Any other distro. Set up and run                  | [Download from the releases page](https://github.com/aunetx/deezer-linux/releases/latest)                                                                                       |
@@ -70,7 +70,7 @@ After installing, launch **Deezer** from your applications menu, or from a termi
 | -------------------- | ------------------------------------------------------------------- |
 | Flatpak              | `flatpak run dev.aunetx.deezer`                                     |
 | Snap                 | `deezer-desktop`                                                    |
-| Nix                  | `deezer-desktop` or `nix run nixpkgs#deezer-desktop`                |
+| Nix                  | `deezer-desktop`                                                    |
 | `.deb` / `.rpm`      | `deezer-desktop`                                                    |
 | `.tar.xz` / AppImage | `./deezer-desktop` (from the extracted folder or the AppImage file) |
 

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 
 let
 
-  src = ./. + "/artifacts/${arch}/linux-unpacked";
+  src = ./. + "/artifacts/${arch}/linux${lib.optionalString (arch != "x64") "-${arch}"}-unpacked";
 
   deezer-desktop = pkgs.stdenv.mkDerivation (finalAttrs: {
     pname = "deezer-desktop";

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,55 @@
+{
+  pkgs ? import <nixpkgs> { config.allowUnfree = true; },
+  pkgVer ? "local",
+  arch ? "x64",
+  lib ? pkgs.lib,
+}:
+
+let
+
+  src = ./. + "/artifacts/${arch}/linux-unpacked";
+
+  deezer-desktop = pkgs.stdenv.mkDerivation (finalAttrs: {
+    pname = "deezer-desktop";
+    version = pkgVer;
+    inherit src;
+
+    nativeBuildInputs = [
+      pkgs.makeWrapper
+    ];
+
+    dontUnpack = true;
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      install -d $out/bin $out/share/deezer-desktop/resources $out/share/applications $out/share/icons/hicolor/scalable/apps
+
+      cp $src/resources/dev.aunetx.deezer.desktop $out/share/applications/
+      substituteInPlace $out/share/applications/dev.aunetx.deezer.desktop \
+        --replace-fail "run.sh" "deezer-desktop"
+      cp $src/resources/dev.aunetx.deezer.svg $out/share/icons/hicolor/scalable/apps/
+      cp -r $src/resources/{app.asar,linux} $out/share/deezer-desktop/resources/
+
+      makeWrapper "${pkgs.lib.getExe pkgs.electron}" "$out/bin/deezer-desktop" \
+        --inherit-argv0 \
+        --add-flags "$out/share/deezer-desktop/resources/app.asar" \
+        --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+        --set DZ_RESOURCES_PATH "$out/share/deezer-desktop/resources"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Unofficial Linux port of the music streaming application";
+      homepage = "https://github.com/aunetx/deezer-linux";
+      downloadPage = "https://github.com/aunetx/deezer-linux/releases";
+      platforms = lib.platforms.linux;
+      license = lib.licenses.unfree;
+      mainProgram = "deezer-desktop";
+    };
+  });
+in
+{
+  "deezer-desktop" = deezer-desktop;
+  default = deezer-desktop;
+}

--- a/package-append.json
+++ b/package-append.json
@@ -3,6 +3,7 @@
     "copy-resources": "mkdir -p resources/linux && cp ../extra/linux/* ./resources/linux",
     "start": "yarn run copy-resources && electron .",
     "prepare-flatpak": "electron-builder --linux --dir",
+    "prepare-nix": "electron-builder --linux --dir",
 
     "build-flatpak-x64": "env DEBUG='@malept/flatpak-bundler' electron-builder --x64 --linux flatpak",
     "build-flatpak-arm64": "env DEBUG='@malept/flatpak-bundler' electron-builder --arm64 --linux flatpak",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    gnumake
+    p7zip
+    nodejs
+    jq
+    wget
+  ];
+}


### PR DESCRIPTION
Deezer-Linux is available in [Nixpkgs](https://search.nixos.org/packages?query=deezer-desktop&show=deezer-desktop) for Nix and NixOS users since March 2026 https://github.com/NixOS/nixpkgs/pull/488329.

This PR aims to add the build instructions and processes for a locally built deezer-linux version for development and contributing purposes.

The Nix's build process just extracts the application components but do not use the packaged Electron. It uses the official version published in Nixpkgs instead.

Updates on Nixpkgs are managed by the bot "R. RyanTM" based on releases from this repository with automatically opened PR (Example : https://github.com/NixOS/nixpkgs/pull/553896). The Nixpkgs CI build the package on their own using the `.tar.xz` releases ~~and push it to https://cache.nixos.org/~~.

Then, the users can just launch a temporary run with :
```sh
nix-shell -p deezer-desktop
```
Or install it permanently by adding to their `configuration.nix` or Flakes :
```nix
{
  environment.systemPackages = with pkgs; [
    deezer-desktop
  ];
}
```